### PR TITLE
trim "v" prefix from version string in fetch command

### DIFF
--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -78,6 +78,8 @@ func makeVersionID(version string) string {
 }
 
 func makeURLs(version string) []string {
+	// remove "v", e.g. v5.0.0 => 5.0.0
+	version = strings.TrimPrefix(version, "v")
 	baseVersionURL := baseURL + "v" + version
 	res, err := http.Get(baseVersionURL)
 	if err != nil {


### PR DESCRIPTION
Hello! Thank you for creating such a great tool. I rather prefer to use this instead of my `get-kernel` tool recently.

BTW `getkernel list` shows versions like `v5.10`, but `getkernel fetch` does not accept this format, i.e. `v` + version.

This PR removes `v` prefix from the version string in `getkernel fetch`. What do you think of it?